### PR TITLE
add dashboard link to menubar for logged in users

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -12,6 +12,10 @@
         <% end %>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+        <% if user_signed_in? %>
+          <li <%= 'class=active' if current_page?('/dashboard') %>>
+            <%= link_to 'Dashboard', '/dashboard', aria: current_page?('/dashboard') ? {current: 'page'} : nil %></li>
+        <% end %>
         <li>
           <%= link_to 'NCELP.org', 'https://ncelp.org/', target: :_blank %></li>
       </ul><!-- /.nav -->


### PR DESCRIPTION
Followed the UI mockup, the traditional Hyrax dashboard has been removed. I've added a 'Dashboard' link to the menubar.