### PR TITLE
customize fields in collection form

### DIFF
--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  module Forms
+      class CollectionForm < Hyrax::Forms::WorkForm
+        self.model_class = ::Collection
+        self.terms = [:title,
+                      :description
+                     ]
+
+        self.required_fields = [
+                      :title,
+                      :description
+                     ]
+        def self.build_permitted_params
+            super + [
+                :visibility
+            ]
+        end
+      end
+  end
+end


### PR DESCRIPTION
Resolves #160 

The default Hyrax collection form tries to load all metadata, including language. However, language_other has been added to support 'other' language option in Resource form. This change redefines the fields to be shown in the collection form, e.g. to exclude the 'language' field.

