### PR TITLE
Few minor changes to search results page

### DIFF
--- a/app/assets/stylesheets/ncelp.scss
+++ b/app/assets/stylesheets/ncelp.scss
@@ -196,7 +196,7 @@ footer.navbar-inverse {
 .ncelp-search-result-resource-div {
   border: 2px solid #eef0f2;
   -moz-border-radius: 15px;
-  border-radius: 15px;
+  border-radius: 10px;
   padding: 10px;
 }
 .ncelp-search-result-resource-field-div {
@@ -205,7 +205,13 @@ footer.navbar-inverse {
   padding-top: 5px;
   padding-bottom: 5px;
 }
-.ncelp-search-result-resource-filetype-icon {
+
+.ncelp-search-result-resource-field-div {
+  padding: 0; 
+  padding-top: 10px;
+}
+
+.ncelp-search-result-resource-filetype-icon{
   height: 50px;
   width: 50px;
 }
@@ -214,6 +220,20 @@ footer.navbar-inverse {
   border: 5px solid white;
   -moz-border-radius: 5px;
   border-radius: 5px;
+  padding-right: 3px;
+  margin-right: 5px;
+  border-right: 1px solid lightgray;
+
+  a {
+    color: #104f75;
+  }
+
+  // Remove border from last child
+  &:last-child {
+    border:0;
+    margin-right: 0;
+  }
+
 }
 // facet header
 div.facets h3 {
@@ -303,6 +323,28 @@ form#surveyform label {
 
 #surveyform .bold {
   font-weight: bold;
+}
+
+#search-results {
+  .search-result-wrapper {
+    margin-bottom: 0;
+  }
+  li {
+    margin-bottom: 15px;
+  }
+  .search-result-title {
+    a {
+      color: #104f75;
+    }
+  }
+}
+
+#facet-panel-collapse {
+  .panel-body {
+    ul {
+      margin-bottom: 0;
+    }
+  }
 }
 
 .resource-title .show-actions,

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,0 +1,1 @@
+<meta name="description" content="NCELP Resource Portal">

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,3 @@
+<div class="search-results-title-row">
+  <h4 class="search-result-title"><%= link_to document.title_or_label, document, :title => document.title_or_label %></h4>
+</div>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,35 +1,34 @@
-<div class="row ncelp-search-result-resource-field-div">
-  <div class="col-md-12">
-    <%= document.one_line_description %>
-  </div>
+<div class="col-md-12">
+  <%= document.one_line_description %>
 </div>
 
-<div class="row ncelp-search-result-resource-field-div">
-  <div class="col-md-12">
+<div class="col-md-12">
+  <div class="ncelp-search-result-resource-field-div">
     <% document.file_type.each do |ft| %>
       <span>
         <%= image_tag(FileTypeIcon.get_icon(ft),
-                      class: "ncelp-search-result-resource-filetype-icon",
-                      alt: GenericLocalAuthorityService.id_to_label('file_type', ft),
-                      title: GenericLocalAuthorityService.id_to_label('file_type', ft))%>
+                class: "ncelp-search-result-resource-filetype-icon",
+                alt: GenericLocalAuthorityService.id_to_label('file_type', ft),
+                title: GenericLocalAuthorityService.id_to_label('file_type', ft))%>
       </span>
     <% end %>
   </div>
 </div>
 
 <% unless document.language.nil? or document.language.length==0 %>
-<div class="row ncelp-search-result-resource-field-div">
-  <div class="col-md-4">
-    <div>
-      Language being learnt
-    </div>
+<div class="col-md-4">
+  <div class="ncelp-search-result-resource-field-div">
+    Language being learnt
   </div>
-  <div class="col-md-8">
-    <% document.language.each do |l| %>
+</div>
+<div class="col-md-8">
+  <div class="ncelp-search-result-resource-field-div">
+    <% document.language.each do |_language| %>
       <span class="ncelp-search-result-resource-field-value">
-        <%= link_to GenericLocalAuthorityService.id_to_label('language', l),
-                     '/catalog?f[language_sim][]='+l+'&locale=en&q=&search_field=all_fields',
-                     :target => "_blank" %>
+        <%= link_to GenericLocalAuthorityService.id_to_label('language', _language),
+              '/catalog?f[language_sim][]=' + _language + '&locale=en&q=&search_field=all_fields',
+              :target => "_blank",
+              :title => _language %>
       </span>
     <% end %>
   </div>
@@ -37,19 +36,19 @@
 <% end %>
 
 <% unless document.type_of_material.nil? %>
-<div class="row ncelp-search-result-resource-field-div">
-  <div class="col-md-4">
-    <div>
-      Type / purpose of resource
-    </div>
+<div class="col-md-4">
+  <div class="ncelp-search-result-resource-field-div">
+    Type / purpose of resource
   </div>
-  <div class="col-md-8">
+</div>
+<div class="col-md-8">
+  <div class="ncelp-search-result-resource-field-div">
     <span class="ncelp-search-result-resource-field-value">
-
-          <%= link_to GenericLocalAuthorityService.id_to_label('type_of_material',document.type_of_material),
-                  '/catalog?f[type_of_material_sim][]='+document.type_of_material+'&locale=en&q=&search_field=all_fields',
-                  :target => "_blank" %>
-
+      <% material_type_title = GenericLocalAuthorityService.id_to_label('type_of_material',document.type_of_material) %>
+      <%= link_to material_type_title,
+            '/catalog?f[type_of_material_sim][]=' + document.type_of_material + '&locale=en&q=&search_field=all_fields',
+            :target => "_blank",
+            :title => material_type_title %>
     </span>
   </div>
 </div>

--- a/app/views/hyrax/base/_authority_field.html.erb
+++ b/app/views/hyrax/base/_authority_field.html.erb
@@ -13,14 +13,16 @@
               %>
               <%= link_to  label,
                            '/catalog?f['+field_name+'_sim][]='+id+'&locale=en&q=&search_field=all_fields',
-                           :target => "_blank"
+                           :target => "_blank",
+                           :title => label
               %>
               <br/>
             <%end%>
           <% else %>
             <%= link_to  GenericLocalAuthorityService.id_to_label(field_name, field_value),
                          '/catalog?f['+field_name+'_sim][]='+field_value+'&locale=en&q=&search_field=all_fields',
-                         :target => "_blank"
+                         :target => "_blank",
+                         :title => GenericLocalAuthorityService.id_to_label(field_name, field_value)
             %>
           <% end %>
         </div>


### PR DESCRIPTION
Sorry this pull request is for the search results page. I pulled in the new changes too because I had to continue working on the styling. Some small changes to the results page are done.


Add title to links
Temp page description
Changing color and background of tags for better contrast reading
Added header list title with title tag
Changing layout - removing the rows and padding
Adding title tags to languages and material type
Updated sqlite3 to 1.3.13 and pg 1.1.4
Updated sqlite3 to version 1.3.13 and postgres to 1.1.4
Homepage improvements
Removed social media links and moved to _show_ncelp_actions.html.erb
Show social media links here to free up space
Show title instead of just `Resource details`
Remove padding for .show-actions and .social-media
Show social media buttons on one line and remove right margin of last item
Update on footer and social media icons
Added hidden label for search field
Modified padding/margin
Modified ALT text of header image
Removing the label again..
Created hiddng H1 and label for search
Remove label font-weight for homepage
Update on browse by - made it DRY and added SEO title tags
Changed tab buttons into real buttons to resolve accessibilty issue
Include link title and image alt to recent documents
Updated some styling
Adding SEO title tags to links
Fix border radius
Changed the if statement
Changed <%- with <%
Added missing styles