### PR TITLE
Fix/issue 222 re instate help page

### DIFF
--- a/app/controllers/hyrax/content_blocks_controller.rb
+++ b/app/controllers/hyrax/content_blocks_controller.rb
@@ -1,0 +1,40 @@
+module Hyrax
+  class ContentBlocksController < ApplicationController
+    load_and_authorize_resource
+    with_themed_layout 'dashboard'
+
+    def edit
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.configuration'), '#'
+      add_breadcrumb t(:'hyrax.admin.sidebar.content_blocks'), hyrax.edit_content_blocks_path
+    end
+
+    def update
+      respond_to do |format|
+        if @content_block.update(value: update_value_from_params)
+          format.html { redirect_to hyrax.edit_content_blocks_path, notice: t(:'hyrax.content_blocks.updated') }
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    private
+
+      def permitted_params
+        params.require(:content_block).permit(:marketing,
+                                              :announcement,
+                                              :researcher,
+                                              :help)
+      end
+
+      # When a request comes to the controller, it will be for one and
+      # only one of the content blocks. Params always looks like:
+      #   {'about_page' => 'Here is an awesome about page!'}
+      # So reach into permitted params and pull out the first value.
+      def update_value_from_params
+        permitted_params.values.first
+      end
+  end
+end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -69,7 +69,8 @@ class ContentBlock < ActiveRecord::Base
     end
 
     def help_page
-      find_or_create_by(name: 'help_page')
+      find_by(name: 'help_page') ||
+        create(name: 'help_page', value: default_help_text)
     end
 
     def help_page=(value)
@@ -97,6 +98,14 @@ class ContentBlock < ActiveRecord::Base
       ERB.new(
         IO.read(
           Hyrax::Engine.root.join('app', 'views', 'hyrax', 'content_blocks', 'templates', 'terms.html.erb')
+        )
+      ).result
+    end
+
+    def default_help_text
+      ERB.new(
+        IO.read(
+            Rails.root.join('app', 'views', 'hyrax', 'content_blocks', 'templates', 'help.html.erb')
         )
       ).result
     end

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -1,0 +1,104 @@
+class ContentBlock < ActiveRecord::Base
+  # The keys in this registry are "public" names for collaborator
+  # objects, and the values are reserved names of ContentBlock
+  # instances, which Hyrax uses as identifiers. Values also correspond
+  # to names of messages that can be sent to the ContentBlock class to
+  # return defined ContentBlock instances.
+  NAME_REGISTRY = {
+    marketing: :marketing_text,
+    researcher: :featured_researcher,
+    announcement: :announcement_text,
+    about: :about_page,
+    help: :help_page,
+    terms: :terms_page,
+    agreement: :agreement_page
+  }.freeze
+
+  # NOTE: method defined outside the metaclass wrapper below because
+  # `for` is a reserved word in Ruby.
+  def self.for(key)
+    key = key.respond_to?(:to_sym) ? key.to_sym : key
+    raise ArgumentError, "#{key} is not a ContentBlock name" unless whitelisted?(key)
+    ContentBlock.public_send(NAME_REGISTRY[key])
+  end
+
+  class << self
+    def whitelisted?(key)
+      NAME_REGISTRY.include?(key)
+    end
+
+    def marketing_text
+      find_or_create_by(name: 'marketing_text')
+    end
+
+    def marketing_text=(value)
+      marketing_text.update(value: value)
+    end
+
+    def announcement_text
+      find_or_create_by(name: 'announcement_text')
+    end
+
+    def announcement_text=(value)
+      announcement_text.update(value: value)
+    end
+
+    def featured_researcher
+      find_or_create_by(name: 'featured_researcher')
+    end
+
+    def featured_researcher=(value)
+      featured_researcher.update(value: value)
+    end
+
+    def about_page
+      find_or_create_by(name: 'about_page')
+    end
+
+    def about_page=(value)
+      about_page.update(value: value)
+    end
+
+    def agreement_page
+      find_by(name: 'agreement_page') ||
+        create(name: 'agreement_page', value: default_agreement_text)
+    end
+
+    def agreement_page=(value)
+      agreement_page.update(value: value)
+    end
+
+    def help_page
+      find_or_create_by(name: 'help_page')
+    end
+
+    def help_page=(value)
+      help_page.update(value: value)
+    end
+
+    def terms_page
+      find_by(name: 'terms_page') ||
+        create(name: 'terms_page', value: default_terms_text)
+    end
+
+    def terms_page=(value)
+      terms_page.update(value: value)
+    end
+
+    def default_agreement_text
+      ERB.new(
+        IO.read(
+          Hyrax::Engine.root.join('app', 'views', 'hyrax', 'content_blocks', 'templates', 'agreement.html.erb')
+        )
+      ).result
+    end
+
+    def default_terms_text
+      ERB.new(
+        IO.read(
+          Hyrax::Engine.root.join('app', 'views', 'hyrax', 'content_blocks', 'templates', 'terms.html.erb')
+        )
+      ).result
+    end
+  end
+end

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -12,6 +12,8 @@
         <% end %>
         <li <%= 'class=active' if current_page?(hyrax.contact_path) %>>
           <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
+        <li <%= 'class=active' if current_page?(hyrax.help_path) %>>
+          <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
         <% if user_signed_in? %>
           <li <%= 'class=active' if current_page?('/dashboard') %>>
             <%= link_to 'Dashboard', '/dashboard', aria: current_page?('/dashboard') ? {current: 'page'} : nil %></li>

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,0 +1,65 @@
+<%= render "shared/nav_safety_modal" %>
+<div class="panel panel-default tabs">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#announcement_text" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.announcement_text') %></a>
+    </li>
+    <li>
+      <a href="#marketing" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.marketing_text') %></a>
+    </li>
+    <li>
+      <a href="#researcher" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div id="announcement_text" class="tab-pane active">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:announcement), url: hyrax.content_block_path(ContentBlock.for(:announcement)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :announcement %><br />
+                <%= f.text_area :announcement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="marketing" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:marketing), url: hyrax.content_block_path(ContentBlock.for(:marketing)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :marketing %><br />
+                <%= f.text_area :marketing, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="researcher" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:researcher), url: hyrax.content_block_path(ContentBlock.for(:researcher)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+                <%= f.label :researcher %><br />
+                <%= f.text_area :researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<%= tinymce :content_block %>

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -10,6 +10,9 @@
     <li>
       <a href="#researcher" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.featured_researcher') %></a>
     </li>
+    <li>
+      <a href="#help" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.help') %></a>
+    </li>
   </ul>
   <div class="tab-content">
     <div id="announcement_text" class="tab-pane active">
@@ -51,6 +54,22 @@
             <div class="field form-group">
                 <%= f.label :researcher %><br />
                 <%= f.text_area :researcher, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="panel-footer">
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right' %>
+            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="help" class="tab-pane">
+      <div class="panel panel-default labels">
+        <%= simple_form_for ContentBlock.for(:help), url: hyrax.content_block_path(ContentBlock.for(:help)), html: {class: 'nav-safety'} do |f| %>
+          <div class="panel-body">
+            <div class="field form-group">
+              <%= f.label :help %><br />
+              <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
             </div>
           </div>
           <div class="panel-footer">

--- a/app/views/hyrax/content_blocks/templates/help.html.erb
+++ b/app/views/hyrax/content_blocks/templates/help.html.erb
@@ -1,0 +1,25 @@
+<h2>Help</h2>
+<br/>
+<p>
+  Please read our brief guide: '<a target="_blank" href="https://drive.google.com/file/d/1wlJMPiuY-PGq9z4Xd9l-ptJ4NoMdoDek/view?usp=sharing">Using the Resource Portal</a>' which contains information on:
+</p>
+<br/>
+<ul>
+  <li>Searching and Browsing by All resources</li>
+  <li>Search results page</li>
+  <li>Resource details page</li>
+  <li>Downloading a resource file</li>
+  <li>Featured Works, Recently Uploaded and Collections</li>
+  <li>Resource Portal Bulletins</li>
+  <li>Contact us</li>
+</ul>
+<br/>
+
+<p style="font-weight: bold">Accessibility:</p>
+<p>
+NCELP is committed to providing resources that are accessible to all in accordance with W3C recommendations. We are actively working to increase the increase the accessibility and usability of our resources, and to meet current guidelines. Please visit our accessibility page for more information.
+</p>
+<br/>
+<p>
+  If the above does not answer your queries or you would like to report a problem with the system, please email <a href="mailto:resources@ncelp.org">resources@ncelp.org</a> with details.
+</p>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -60,3 +60,5 @@ en:
     institution_name_full: "National Centre for Excellence for Language Pedagogy"
     product_name: NCELP
     product_twitter_handle: "@ncelp"
+    content_blocks:
+      help: Help


### PR DESCRIPTION
Resolves #222 

Adds the following files to support the new Help content block:
- content_blocks_controller
- content_block model
- form.html.erb for content block
- default help page
- Help menu