### PR TITLE
add missing attributes to make the zip file checking JS code working

### DIFF
--- a/app/assets/javascripts/ncelp.js
+++ b/app/assets/javascripts/ncelp.js
@@ -123,6 +123,8 @@ $(document).on('turbolinks:load', function() {
         var zipfileurl = window.location.origin + "/zipfiles/" + collectionid + ".zip";
 
         $.ajax({
+            type: 'HEAD',
+            async: true,
             url: zipfileurl,
             statusCode: {
                 404: function () {

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -102,6 +102,8 @@
         <% unless (session['has_done_survey'] == 'yes' or collectionid.nil?) %>
           <a data-fancybox
              class="btn btn-primary"
+             id="collection_download_all"
+             style="display:none; width: 107px;"
              data-type="iframe"
              data-captain="Downloader Survey"
              data-src="/survey/new?from=collection&collection_id=<%= collectionid %>"
@@ -119,6 +121,7 @@
           <button id="collection_download_all" class="btn btn-primary" style="display:none">Download All</button>
         <% end %>
       </div>
+      <br/>
 
       <div class="hyc-blacklight hyc-bl-pager">
         <%= render 'paginate' %>


### PR DESCRIPTION
While user hasn't done the download survey, and the zip file for current collection doesn't exist, hide 'Download All' button.